### PR TITLE
Add syntax highlighted pastes and web based interface

### DIFF
--- a/routes/route.ts
+++ b/routes/route.ts
@@ -69,10 +69,26 @@ router.post("/", async (ctx) => {
 });
 
 // Display stored pastes for a particular id
-router.get<{ id: string }>("/:id", (ctx) => {
+router.get<{ id: string }>("/raw/:id", (ctx) => {
   ctx.response.body = ctx.params && pastes.has(ctx.params.id)
     ? pastes.get(ctx.params.id)?.content
     : "No paste for this id";
+});
+
+// Display stored pastes for a particular id with syntax highlighting
+router.get<{ id: string }>("/:id", (ctx) => {
+  const paste = ctx.params && pastes.has(ctx.params.id)
+    ? `<!DOCTYPE html>
+    <html>
+      <head>
+        <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
+      </head>
+      <body>
+        <pre class="prettyprint">${pastes.get(ctx.params.id)?.content}</pre>
+      </body>
+    </html>`
+    : "No paste for this id";
+  ctx.response.body = paste;
 });
 
 // Added the delete method

--- a/routes/route.ts
+++ b/routes/route.ts
@@ -20,6 +20,19 @@ router.get("/", (ctx) => {
   ctx.response.body = "Hello World!";
 });
 
+router.get("/web", async (ctx) => {
+  try {
+    await ctx.send(
+      {
+        root: `./static`,
+        path: "index.html",
+      },
+    );
+  } catch (error) {
+    console.log(error);
+  }
+});
+
 // Store pastes in a generated id
 router.post("/", async (ctx) => {
   if (!ctx.request.hasBody) {

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>paste.land</title>
+    <meta name="author" content="Barun Acharya" />
+    <meta
+      name="description"
+      content="paste.land is a paste tool made in deno. It aims to ease out sharing short code samples, logs, links, markdown notes or any other form of text."
+    />
+  </head>
+  <style>
+    textarea {
+      box-sizing: border-box;
+      width: 100%;
+    }
+  </style>
+  <body>
+    <form method="POST" action="/">
+      <textarea
+        name="Content"
+        placeholder="Paste your code here..."
+        rows="30"
+      ></textarea>
+      <input type="submit" value="Paste!" />
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
Navigate to `/web/` for the form.
`GET /:id` now gives syntax highlighted code.
`GET /raw/:id` gives raw untouched paste

Syntax highlighting is done through [`code-prettify`](https://github.com/googlearchive/code-prettify)

Closes #13 